### PR TITLE
revert to non-corrupted version of colors package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 [#x]: https://github.com/ideditor/schema-builder/issues/x
 -->
 
+# 4.0.5
+##### 2022-Jan-10
+
+* Fix to a working version of a broken ("corrupted") dependency
+
 # 4.0.4
 ##### 2020-Dec-10
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "btoa": "^1.2.1",
-    "colors": "^1.1.2",
+    "colors": "1.4.0",
     "glob": "^7.1.0",
     "js-yaml": "^4.0.0",
     "jsonschema": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ideditor/schema-builder",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Framework for defining iD-compatible tagging models",
   "homepage": "https://github.com/ideditor/schema-builder#readme",
   "bugs": "https://github.com/ideditor/schema-builder/issues",


### PR DESCRIPTION
see https://www.bleepingcomputer.com/news/security/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps/

this currently makes all tests fail, see e.g. https://github.com/openstreetmap/id-tagging-schema/runs/4759030935?check_suite_focus=true#step:5:11