### PR TITLE
either "key" or "keys" must be present on all⁽¹⁾ fields

### DIFF
--- a/schemas/field.json
+++ b/schemas/field.json
@@ -246,8 +246,15 @@
         }
     },
     "additionalProperties": false,
-    "oneOf": [
-        { "$id": "field-with-key", "required": ["key"] },
-        { "$id": "field-with-keys", "required": ["keys"] }
+    "anyOf": [
+        { "$id": "field-type-no-key", "properties": { "type": { "enum": ["restrictions"] } } },
+        { "$id": "field-type-key-keys", "properties": { "type": { "enum": ["address", "wikipedia", "wikidata"] } }, "required": ["key", "keys"] },
+        { "allOf": [
+            { "not": { "properties": { "type": { "enum": ["address", "wikipedia","wikipedia",  "wikidata", "restrictions"] } } } },
+            { "oneOf": [
+                { "$id": "field-with-key", "required": ["key"] },
+                { "$id": "field-with-keys", "required": ["keys"] }
+            ]}
+        ]}
     ]
 }

--- a/schemas/field.json
+++ b/schemas/field.json
@@ -245,5 +245,9 @@
             "enum": ["preset", "changeset", "manual", "group"]
         }
     },
-    "additionalProperties": false
+    "additionalProperties": false,
+    "oneOf": [
+        { "$id": "field-with-key", "required": ["key"] },
+        { "$id": "field-with-keys", "required": ["keys"] }
+    ]
 }

--- a/schemas/field.json
+++ b/schemas/field.json
@@ -247,13 +247,13 @@
     },
     "additionalProperties": false,
     "anyOf": [
-        { "$id": "field-type-no-key", "properties": { "type": { "enum": ["restrictions"] } } },
-        { "$id": "field-type-key-keys", "properties": { "type": { "enum": ["address", "wikipedia", "wikidata"] } }, "required": ["key", "keys"] },
-        { "allOf": [
+        { "$id": "field-type-without-key", "properties": { "type": { "enum": ["restrictions"] } } },
+        { "$id": "field-type-with-key-and-keys", "properties": { "type": { "enum": ["address", "wikipedia", "wikidata"] } }, "required": ["key", "keys"] },
+        { "$id": "field-type-with-key-or-keys", "allOf": [
             { "not": { "properties": { "type": { "enum": ["address", "wikipedia","wikipedia",  "wikidata", "restrictions"] } } } },
             { "oneOf": [
-                { "$id": "field-with-key", "required": ["key"] },
-                { "$id": "field-with-keys", "required": ["keys"] }
+                { "required": ["key"] },
+                { "required": ["keys"] }
             ]}
         ]}
     ]


### PR DESCRIPTION
This add a check to the schema, making sure that no fields[^1] without a `key` or `keys` property are added. 

see https://github.com/openstreetmap/id-tagging-schema/issues/676

[^1]: exceptions to the rule exist for field types `address`, `wikidata`, `wikipedia` and `restrictions`