### PR TITLE
schemas/field: Fix `prerequisiteTag`

### DIFF
--- a/schemas/field.json
+++ b/schemas/field.json
@@ -168,40 +168,38 @@
         },
         "prerequisiteTag": {
             "description": "Tagging constraint for showing this field in the editor",
-            "type": {
-                "anyOf": [
-                    {
-                        "type": "object",
-                        "properties": {
-                            "key": {
-                                "description": "The key of the required tag",
-                                "type": "string",
-                                "required": true
-                            },
-                            "value": {
-                                "description": "The value that the tag must have. (alternative to 'valueNot')",
-                                "type": "string"
-                            },
-                            "valueNot": {
-                                "description": "The value that the tag cannot have. (alternative to 'value')",
-                                "type": "string"
-                            }
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "key": {
+                            "description": "The key of the required tag",
+                            "type": "string",
+                            "required": true
                         },
-                        "additionalProperties": false
+                        "value": {
+                            "description": "The value that the tag must have. (alternative to 'valueNot')",
+                            "type": "string"
+                        },
+                        "valueNot": {
+                            "description": "The value that the tag cannot have. (alternative to 'value')",
+                            "type": "string"
+                        }
                     },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "keyNot": {
-                                "description": "A key that must not be present",
-                                "type": "string",
-                                "required": true
-                            }
-                        },
-                        "additionalProperties": false
-                    }
-                ]
-            }
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "keyNot": {
+                            "description": "A key that must not be present",
+                            "type": "string",
+                            "required": true
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
         },
         "terms": {
             "description": "English synonyms or related search terms",


### PR DESCRIPTION
https://json-schema.org/understanding-json-schema/reference/combining.html#anyof suggest, that the additional `type` key should not be there. 

I tested that locally in id-tagging-schema by modifying my node_modules file (and reloading the extensions in VS Code) and that god rid of the error from #80.

Fixes https://github.com/ideditor/schema-builder/issues/80