### PR TITLE
Extend Transifex developer notes for multi key field options

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -404,10 +404,15 @@ function generateTranslations(fields, presets, tstrings, searchableFieldIDs) {
       yamlField['#label'] = field.keys.map(k => `${k}=*`).join(', ');
     } else if (field.key) {
       yamlField['#label'] = `${field.key}=*`;
-      optkeys.forEach(k => {
-        options['#' + k] = `${field.key}=${k}`;
-      });
     }
+    optkeys.forEach(k => {
+      if (typeof options[k] === 'string'){
+        options['#' + k] = field.key ? `${field.key}=${k}` : `field "${fieldId}" with value "${k}"`;
+      } else {
+        options[k]['#description'] = `description for ${field.key}=${k}`;
+        options[k]['#title'] = `title for ${field.key}=${k}`;
+      }
+    });
 
     if (yamlField.placeholder) {
       yamlField['#placeholder'] = `${fieldId} field placeholder`;


### PR DESCRIPTION
Those developer notes where already present for some of the keys. This PR add them for multi keys and keys as object as well.