### PR TITLE
Extend Transifex developer notes for label and name about `locationSet.include` countries

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -409,6 +409,10 @@ function generateTranslations(fields, presets, tstrings, searchableFieldIDs) {
       });
     }
 
+    if (field.locationSet?.include) {
+      yamlField['#label'] += ` | Local preset for countries ${field.locationSet.include.map(country => `"${country.toUpperCase()}"`).join(', ')}`;
+    }
+
     if (yamlField.placeholder) {
       yamlField['#placeholder'] = `${fieldId} field placeholder`;
     }
@@ -442,6 +446,10 @@ function generateTranslations(fields, presets, tstrings, searchableFieldIDs) {
         yamlPreset['#name'] += ' | ' + yamlPreset.aliases.split('\n').join(', ');
       }
       yamlPreset['#name'] += ' | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key).';
+    }
+
+    if (preset.locationSet?.include) {
+      yamlPreset['#name'] += ` | Local preset for countries ${preset.locationSet.include.map(country => `"${country.toUpperCase()}"`).join(', ')}`;
     }
 
     if (preset.searchable !== false) {


### PR DESCRIPTION
With this PR, it becomes easier for translators to skip local presets. It adds notes on local presets to the Transifex developer notes.

It is based on the field `locationSet: ['de']` which exists for fields and presets. However, we only look at `locationSet.includes` for those notes. We skip `locationSet.excludes` because that would suggest that a translation is not needed, which can be wrong in cases, where the keys are reused / referenced in another preset. The translation is only done once but have multiple references with different `locationSet`s.

Related
- https://github.com/openstreetmap/id-tagging-schema/pull/331#discussion_r779251632
- https://github.com/ideditor/schema-builder/issues/27

Closes https://github.com/ideditor/schema-builder/issues/27