### PR TITLE
fix id-tagging-schema broken on windows

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -220,7 +220,9 @@ function validateSchema(file, instance, schema) {
 function generateCategories(dataDir, tstrings) {
   let categories = {};
 
-  globSync(dataDir + '/preset_categories/*.json').forEach(file => {
+  globSync(dataDir + '/preset_categories/*.json', {
+    posix: true,
+  }).forEach(file => {
     let category = read(file);
     validateSchema(file, category, categorySchema);
 
@@ -238,7 +240,9 @@ function generateCategories(dataDir, tstrings) {
 function generateFields(dataDir, tstrings, searchableFieldIDs) {
   let fields = {};
 
-  globSync(dataDir + '/fields/**/*.json').forEach(file => {
+  globSync(dataDir + '/fields/**/*.json', {
+    posix: true,
+  }).forEach(file => {
     let field = read(file);
     let id = stripLeadingUnderscores(file.match(/fields\/([^.]*)\.json/)[1]);
 
@@ -298,7 +302,9 @@ function generatePresets(dataDir, tstrings, searchableFieldIDs, listReusedIcons)
 
   let icons = {};
 
-  globSync(dataDir + '/presets/**/*.json').forEach(file => {
+  globSync(dataDir + '/presets/**/*.json', {
+    posix: true,
+  }).forEach(file => {
     let preset = read(file);
     let id = stripLeadingUnderscores(file.match(/presets\/([^.]*)\.json/)[1]);
 


### PR DESCRIPTION
id-tagging-schema no longer runs on windows due to breaking changes from #91 and d1bb56bfbd1327f30e4410f7f0ec649b747a108b, since glob v9+ now uses `\` on windows by default