### PR TITLE
Fix typo in iconCrossReferences in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ Combo field types can accept key-label pairs in the `options` value of the `stri
 }
 ```
 
-##### `iconsCrossReferences`
+##### `iconsCrossReference`
 
 An optional property to reference to the icons of another field, indicated  by using that field's name contained in brackets, like `{field}`. This is for example useful when there are multiple variants of fields for the same tag, which should all use the same icons.
 


### PR DESCRIPTION
Just a typo, the schema and the data do not have `s` at the end.