### PR TITLE
Add schedule field type

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ A string specifying the UI and behavior of the field. Must be one of the followi
 * `url` - Text field for entering URLs
 * `identifier` - Text field for foreign IDs (e.g. `gnis:feature_id`)
 * `colour` - Text field for entering colours
+* `schedule` - Field for entering a recurring schedule (e.g., `opening_hours=*`, `service_times=*`)
 * `textarea` - Multi-line text area (e.g. `description=*`)
 * `date` - Text field for entering dates in ISO 8601 format.
 

--- a/schemas/field.json
+++ b/schemas/field.json
@@ -69,6 +69,7 @@
                 "restrictions",
                 "roadheight",
                 "roadspeed",
+                "schedule",
                 "semiCombo",
                 "structureRadio",
                 "tel",


### PR DESCRIPTION
Added a new field type `schedule` for any field that accepts the opening_hours syntax.

The term “schedule” was chosen to avoid implying that it’s only for the timespan semantics in `opening_hours` as opposed to the point-in-time semantics in `service_times` or `collection_times`. A basic UI for all three keys would look essentially the same, especially on native platforms that provide standard controls for this sort of thing. The differences in a more sophisticated custom UI would be minor enough that we can make the distinction in a separate property if necessary.

Fixes #100.