### PR TITLE
Docs: Add section about deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ See the [location-conflation](https://github.com/ideditor/location-conflation) p
 
 The ID of a preset that is preferable to this one. iD's validator will flag features matching this preset and recommend that the user upgrade the tags.
 
-When possible, use `deprecated.json` instead to specify upgrade paths for old tags. This property is meant for special cases, such as upgrades with geometry requirements.
+When possible, use [`deprecated.json`](#deprecations) instead to specify upgrade paths for old tags. This property is meant for special cases, such as upgrades with geometry requirements.
 
 ##### `reference`
 
@@ -690,6 +690,39 @@ Combo field types can accept key-label pairs in the `options` value of the `stri
 
 An optional property to reference to the icons of another field, indicated  by using that field's name contained in brackets, like `{field}`. This is for example useful when there are multiple variants of fields for the same tag, which should all use the same icons.
 
+### Deprecations
+
+Use `deprecated.json` ([Example](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/deprecated.json), [Schema](https://github.com/ideditor/schema-builder/blob/main/schemas/deprecated.json)) to specify tag deprecations.
+
+Editors can use this list to update deprecated tags. For example, iD Editor will automatically and silently change tags when an OSM object was modified.
+
+**Example: Default Case**
+
+To update a specific tag to a specific new tag
+
+```
+  {
+    "old": {"foo": "value"},
+    "replace": {"bar": "value"}
+  },
+```
+
+**Example: Change the key, keep the value**
+
+```
+  {
+    "old": {"foo": "*"},
+    "replace": {"bar": "$1"}
+  },
+```
+
+**Example: Delete a tag**
+
+```
+  {
+    "old": {"content": "unknown"}
+  },
+```
 
 ## Contributing
 


### PR DESCRIPTION
I was looking for docs on how the deprecation system work but could not find any. Did I miss it?

This adds my best guess on how the system likely works. Especially the "Delete Tags" Case is a guess…

---

Also, since it is quite hard to find the docs from this repo/page on the https://github.com/openstreetmap/id-tagging-schema/ repo, I think it might be worth linking this deprecation section from https://github.com/openstreetmap/id-tagging-schema/blob/main/CONTRIBUTING.md or somewhere, so that there is some link that one can search for via the Github repository search.