### PR TITLE
Remove size from maki urls

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -536,7 +536,7 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
     // add icon
     if (/^maki-/.test(preset.icon)) {
       tag.icon_url = 'https://cdn.jsdelivr.net/gh/mapbox/maki/icons/' +
-        preset.icon.replace(/^maki-/, '') + '-15.svg';
+        preset.icon.replace(/^maki-/, '') + '.svg';
     } else if (/^temaki-/.test(preset.icon)) {
       tag.icon_url = 'https://cdn.jsdelivr.net/gh/rapideditor/temaki/icons/' +
         preset.icon.replace(/^temaki-/, '') + '.svg';


### PR DESCRIPTION
I'm a little lost, but I think I've found the right place.

This all started with a 404. Specifically [id-tagging-schema](https://github.com/openstreetmap/id-tagging-schema/blob/f2c16fbcd665ff7d8a56f44b1581a15bdc0328f6/dist/taginfo.json#L10981) references `https://cdn.jsdelivr.net/gh/mapbox/maki/icons/toll-15.svg`. Interestingly `https://cdn.jsdelivr.net/gh/mapbox/maki/icons/toll.svg` works. I checked a few other maki urls and the seem to work with both url formats, the images look the same to me, but aren't byte for byte the same.
eg `https://cdn.jsdelivr.net/gh/mapbox/maki/icons/shop-15.svg` vs `https://cdn.jsdelivr.net/gh/mapbox/maki/icons/shop.svg`.

I've found my [maki-toll](https://github.com/openstreetmap/id-tagging-schema/blob/f2c16fbcd665ff7d8a56f44b1581a15bdc0328f6/data/presets/barrier/toll_booth.json#L2), but no `15`. Time to head up a level, and here we are.

But why are most of the `15`s working? 

It seems maki deprecated the `15` and `11` sizes in [v7](https://github.com/mapbox/maki/blob/main/CHANGELOG.md). The new icons only work on `https://cdn.jsdelivr.net/gh/mapbox/maki/icons/animal-shelter.svg`, not `https://cdn.jsdelivr.net/gh/mapbox/maki/icons/animal-shelter-15.svg`. My guess is the CDN still has old files on the old urls, with new files on the new urls.

So no icons from here will have any changes since pre v7, and new icons 404.