### PR TITLE
Readme: Clarify referencing for `name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The primary name of the feature type.
 
 Upon merging into the `main` branch, this is sent to Transifex for translating to other localizations. Changing the name of an existing preset will require it to be re-translated to all localizations.
 
-A preset can optionally reference the label of another by using that preset's name contained in brackets, like `{preset}`. In which case the presets's _terms_ and _aliases_ are also automatically sourced from that other field. This is for example useful for regional presets which should get the same labels as the preset they are based on.
+A preset can optionally reference the name of another by using that preset's name in brackets, like `{folder/preset}`. In which case the presets's _terms_ and _aliases_ are also automatically sourced from that other field. This is for example useful for regional presets which should get the same labels as the preset they are based on.
 
 This property is required. There is no default.
 


### PR DESCRIPTION
I think this wording should be like in this PR, right?

However, I am not sure if this whole part is actually true. does adding a reference for the `name` really mean that also `terms` and `aliases` are copied? Is there a way around this, like adding `terms` (or an empty array) in the present itself?

Or could it be that one has to reference the preset for each of those keys separately? 

> A preset can optionally reference the label of another by using that preset's name contained in brackets, like {preset}. In which case the presets's terms and aliases are also automatically sourced from that other field. This is for example useful for regional presets which should get the same labels as the preset they are based on.

