### PR TITLE
Docs: Document "strings" with "title" and "description"

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,10 +558,13 @@ The user can pick from any of the options, or type their own value.
 
 The `strings` object contains values that the field wants to be translated on Transifex.
 
-[Combo field types](#combodropdown-fields) can accept key-label pairs in the `options` value of the `strings` property.
+[Combo field types](#combodropdown-fields) can accept custom translations for `options` values via the `strings` property.
 These values populate the `options` property if it isn't otherwise specified.
 If `autoSuggestions` is `true` (as per default), then raw and labeled values might be mixed
 in the dropdown suggestions.
+
+The options can either be a string or `{"title": "…", "description": "…"}` object where the description is shown on mouse over 
+in iD to give additional context on a value ([Example](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/fields/parking.json)).
 
 ```js
 {
@@ -582,6 +585,20 @@ in the dropdown suggestions.
         }
     }
 }
+```
+
+```js
+//…
+    "strings": {
+        "options": {
+            "excellent": {
+                "title": "Thin Rollers: rollerblade, skateboard",
+                "description": "As-new asphalt or concrete, smooth paving stones with seamless connections, etc."
+            },
+            //…
+        }
+    }
+//–
 ```
 
 [Checkbox field tyes](#checkboxes) use the options keys to specify the values of the OSM tag corresponding 


### PR DESCRIPTION
I did not find any docs on this, yet.