### PR TITLE
fix taginfo file not including base tags for `directionalCombo`

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -488,7 +488,7 @@ function generateTranslations(fields, presets, tstrings, searchableFieldIDs) {
 
 function generateTaginfo(presets, fields, deprecated, discarded, tstrings, projectInfo) {
 
-  const packageInfo = JSON.parse(fs.readFileSync('./package.json'));
+  const packageInfo = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
 
   if (!projectInfo.name) projectInfo.name = packageInfo.name;
   if (!projectInfo.description) projectInfo.description = packageInfo.description;
@@ -558,6 +558,13 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
     const field = fields[id];
     const keys = field.keys || (field.key && [field.key]) || [];
     const isRadio = (field.type === 'radio' || field.type === 'structureRadio');
+
+    if (field.type === 'directionalCombo') {
+      // for directionalCombo, only :left and :right are included in field.keys,
+      // so we need to explicitly add the two other possibilities.
+      const base = field.key.replace(/:both$/, '');
+      keys.push(base, `${base}:both`);
+    }
 
     keys.forEach(key => {
       let tag = { key: key };


### PR DESCRIPTION
Discovered in https://github.com/openstreetmap/id-tagging-schema/issues/1641#issuecomment-3105544640, the taginfo file only contains `cycleway:left` and `cycleway:right` , but not `cycleway`[^1] and `cycleway:both`.


[^1]: actually `cycleway` is included because it's used by other presets like `cycleway=crossing`