### PR TITLE
fix taginfo file only including the last key-value pair in the object

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -486,6 +486,19 @@ function generateTranslations(fields, presets, tstrings, searchableFieldIDs) {
 }
 
 
+/**
+ * @import * as Taginfo from 'taginfo-projects'
+ *
+ * this library doesn't follow the type-defintions strictly, it uses `string[]` instead
+ * of `string` for the description field.
+ *
+ * @typedef {Omit<Taginfo.Tag, "description"> & { description?: string[] }} TaginfoTag
+ * @typedef {Omit<Taginfo.Schema, "tags"> & { tags: TaginfoTag[] }} TaginfoSchema
+ */
+
+/**
+ * @param {Taginfo.Project} projectInfo
+ */
 function generateTaginfo(presets, fields, deprecated, discarded, tstrings, projectInfo) {
 
   const packageInfo = JSON.parse(fs.readFileSync('./package.json'));
@@ -504,6 +517,7 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
     }
   }
 
+  /** @type {TaginfoSchema} */
   let taginfo = {
     data_format: 1,
     project: projectInfo,
@@ -515,43 +529,51 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
     if (preset.suggestion) return;
     if (id.startsWith('@')) return;
 
-    let keys = Object.keys(preset.tags);
-    let last = keys[keys.length - 1];
-    let tag = { key: last };
-
-    if (!last) return;
-
-    if (preset.tags[last] !== '*') {
-      tag.value = preset.tags[last];
+    /** @type {Record<string, Set<string>>} */
+    const everyTag = {};
+    for (const group of [preset.tags, preset.addTags, preset.removeTags]) {
+      for (const key in group) {
+          everyTag[key] ||= new Set();
+          everyTag[key].add(preset.tags[key]);
+      }
     }
 
-    let name = tstrings.presets[id].name;
-    if (!name && preset.name.startsWith('{')) {
-      name = tstrings.presets[preset.name.slice(1, -1)].name;
-    }
-    let legacy = (preset.searchable === false) ? ' (unsearchable)' : '';
-    tag.description = [ `🄿 ${name}${legacy}` ];
+    for (const key in everyTag) {
+      for (const value of everyTag[key]) {
+        /** @type {TaginfoTag} */
+        let tag = { key };
+        if (value !== '*') tag.value = value;
 
-    if (preset.geometry) {
-      setObjectType(tag, preset);
-    }
 
-    // add icon
-    if (/^maki-/.test(preset.icon)) {
-      tag.icon_url = 'https://cdn.jsdelivr.net/gh/mapbox/maki/icons/' +
-        preset.icon.replace(/^maki-/, '') + '.svg';
-    } else if (/^temaki-/.test(preset.icon)) {
-      tag.icon_url = 'https://cdn.jsdelivr.net/gh/rapideditor/temaki/icons/' +
-        preset.icon.replace(/^temaki-/, '') + '.svg';
-    } else if (/^fa[srb]-/.test(preset.icon)) {
-      tag.icon_url = 'https://cdn.jsdelivr.net/gh/openstreetmap/iD@develop/svg/fontawesome/' +
-        preset.icon + '.svg';
-    } else if (/^iD-/.test(preset.icon)) {
-      tag.icon_url = 'https://cdn.jsdelivr.net/gh/openstreetmap/iD@develop/svg/iD-sprite/presets/' +
-        preset.icon.replace(/^iD-/, '') + '.svg';
-    }
+        let name = tstrings.presets[id].name;
+        if (!name && preset.name.startsWith('{')) {
+          name = tstrings.presets[preset.name.slice(1, -1)].name;
+        }
+        let legacy = (preset.searchable === false) ? ' (unsearchable)' : '';
+        tag.description = [ `🄿 ${name}${legacy}` ];
 
-    coalesceTags(taginfo, tag);
+        if (preset.geometry) {
+          setObjectType(tag, preset);
+        }
+
+        // add icon
+        if (/^maki-/.test(preset.icon)) {
+          tag.icon_url = 'https://cdn.jsdelivr.net/gh/mapbox/maki/icons/' +
+            preset.icon.replace(/^maki-/, '') + '.svg';
+        } else if (/^temaki-/.test(preset.icon)) {
+          tag.icon_url = 'https://cdn.jsdelivr.net/gh/rapideditor/temaki/icons/' +
+            preset.icon.replace(/^temaki-/, '') + '.svg';
+        } else if (/^fa[srb]-/.test(preset.icon)) {
+          tag.icon_url = 'https://cdn.jsdelivr.net/gh/openstreetmap/iD@develop/svg/fontawesome/' +
+            preset.icon + '.svg';
+        } else if (/^iD-/.test(preset.icon)) {
+          tag.icon_url = 'https://cdn.jsdelivr.net/gh/openstreetmap/iD@develop/svg/iD-sprite/presets/' +
+            preset.icon.replace(/^iD-/, '') + '.svg';
+        }
+
+        coalesceTags(taginfo, tag);
+      }
+    }
   });
 
   Object.keys(fields).forEach(id => {
@@ -560,6 +582,7 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
     const isRadio = (field.type === 'radio' || field.type === 'structureRadio');
 
     keys.forEach(key => {
+      /** @type {TaginfoTag} */
       let tag = { key: key };
 
       let label = tstrings.fields[id].label;
@@ -573,6 +596,7 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
       if (field.options && !isRadio && field.type !== 'manyCombo') {
         field.options.forEach(value => {
           if (value === 'undefined' || value === '*' || value === '') return;
+          /** @type {TaginfoTag} */
           let tag;
           if (field.type === 'multiCombo') {
             tag = { key: key + value };
@@ -600,6 +624,7 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
     let oldKeys = Object.keys(old);
     if (oldKeys.length === 1) {
       let oldKey = oldKeys[0];
+      /** @type {TaginfoTag} */
       let tag = { key: oldKey };
 
       let oldValue = old[oldKey];
@@ -622,6 +647,7 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
   if (!discarded) discarded = {};
   Object.keys(discarded).forEach(key => {
     let description = '🄳🄳 (discarded tag)';
+    /** @type {TaginfoTag} */
     let tag = {
       key,
       description: [description]
@@ -636,6 +662,10 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
   });
 
 
+  /**
+   * @param {TaginfoSchema} taginfo
+   * @param {TaginfoTag} tag
+   */
   function coalesceTags(taginfo, tag) {
     if (!tag.key) return;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "shelljs": "^0.9.2"
       },
       "devDependencies": {
+        "@types/taginfo-projects": "github:taginfo/taginfo-projects#6daafd2e30a86a8bfb9615855af2c2d73bd98279",
         "eslint": "^9.0.0",
         "jest": "^29.1.1"
       },
@@ -1615,6 +1616,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true
+    },
+    "node_modules/@types/taginfo-projects": {
+      "version": "0.0.0",
+      "resolved": "git+ssh://git@github.com/taginfo/taginfo-projects.git#6daafd2e30a86a8bfb9615855af2c2d73bd98279",
+      "integrity": "sha512-+teXwuymBcJGDAQiD8C4ViiQ9wbFdyBer7Yz+uxPKyzKhgJC78bFw5q7fCQI34nynvKkRbf3nyDZAAISfQK3dw==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -6700,6 +6707,12 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "@types/taginfo-projects": {
+      "version": "git+ssh://git@github.com/taginfo/taginfo-projects.git#6daafd2e30a86a8bfb9615855af2c2d73bd98279",
+      "integrity": "sha512-+teXwuymBcJGDAQiD8C4ViiQ9wbFdyBer7Yz+uxPKyzKhgJC78bFw5q7fCQI34nynvKkRbf3nyDZAAISfQK3dw==",
+      "dev": true,
+      "from": "@types/taginfo-projects@github:taginfo/taginfo-projects#6daafd2e30a86a8bfb9615855af2c2d73bd98279"
     },
     "@types/yargs": {
       "version": "17.0.31",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "shelljs": "^0.9.2"
   },
   "devDependencies": {
+    "@types/taginfo-projects": "github:taginfo/taginfo-projects#6daafd2e30a86a8bfb9615855af2c2d73bd98279",
     "eslint": "^9.0.0",
     "jest": "^29.1.1"
   },


### PR DESCRIPTION
(this PR needs to be reviewed with <kbd>Hide whitespace changes</kbd> enabled)

Currently the taginfo file only includes the _last_ tag for each preset, which is pretty weird. It doesn't consider `addTags` or `removeTags`.
