### PR TITLE
allow fields &  presets to reference the `locationSet` from other files

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,11 @@ See the [location-conflation](https://github.com/ideditor/location-conflation) p
 }
 ```
 
+Alternatively, `locationSetCrossReference` can be use to reference the `locationSet` property from another field or preset:
+```json
+"locationSetCrossReference": "{presets/man_made/crane}"
+```
+
 ##### `replacement`
 
 The ID of a preset that is preferable to this one. iD's validator will flag features matching this preset and recommend that the user upgrade the tags.
@@ -703,6 +708,11 @@ See the [location-conflation](https://github.com/ideditor/location-conflation) p
     "include": ["US"],
     "exclude": ["PR", "VI"]
 }
+```
+
+Alternatively, `locationSetCrossReference` can be use to reference the `locationSet` property from another field or preset:
+```json
+"locationSetCrossReference": "{fields/crane/type}"
 ```
 
 ##### `urlFormat`

--- a/lib/build.js
+++ b/lib/build.js
@@ -465,8 +465,13 @@ function generateTranslations(fields, presets, tstrings, searchableFieldIDs) {
       }
     });
 
-    if (field.locationSet?.include) {
-      yamlField['#label'] += ` | Local preset for countries ${field.locationSet.include.map(country => `"${country.toUpperCase()}"`).join(', ')}`;
+    if (field.locationSet) {
+      if (field.locationSet.include) {
+        yamlField['#label'] += ` | Local preset for countries ${field.locationSet.include.map(country => `"${country.toUpperCase()}"`).join(', ')}`;
+      }
+      if (field.locationSet.exclude) {
+        yamlField['#label'] += ` | Hidden in some countries: ${field.locationSet.exclude.map(country => `"${country.toUpperCase()}"`).join(', ')}`;
+      }
     }
 
     if (yamlField.placeholder) {

--- a/lib/references.js
+++ b/lib/references.js
@@ -39,6 +39,26 @@ export function dereferenceUntranslatedContent(presets, fields) {
         }
       }
     }
+
+    // 9. presets can reference the locationSet from other fields or presets
+    if (preset.locationSetCrossReference) {
+      const [type, ...foreignId] = preset.locationSetCrossReference
+        .slice(1, -1)
+        .split('/');
+
+      const referenced = (
+        type === 'presets' ? presets : type === 'fields' ? fields : {}
+      )[foreignId.join('/')];
+
+      if (!referenced) {
+        throw new Error(
+          `Preset “${presetID}” references “${foreignId}” in locationSetCrossReference, but there is no such ${type}.`,
+        );
+      }
+
+      preset.locationSet = referenced.locationSet;
+      delete preset.locationSetCrossReference;
+    }
   }
 
   for (const fieldID in fields) {
@@ -56,6 +76,26 @@ export function dereferenceUntranslatedContent(presets, fields) {
 
       field.icons = referencedField.icons;
       delete field.iconsCrossReference;
+    }
+
+    // 10. fields can reference the locationSet from other fields or presets
+    if (field.locationSetCrossReference) {
+      const [type, ...foreignId] = field.locationSetCrossReference
+        .slice(1, -1)
+        .split('/');
+
+      const referenced = (
+        type === 'presets' ? presets : type === 'fields' ? fields : {}
+      )[foreignId.join('/')];
+
+      if (!referenced) {
+        throw new Error(
+          `Field “${fieldID}” references “${foreignId}” in locationSetCrossReference, but there is no such ${type}.`,
+        );
+      }
+
+      field.locationSet = referenced.locationSet;
+      delete field.locationSetCrossReference;
     }
   }
 }

--- a/schemas/field.json
+++ b/schemas/field.json
@@ -340,6 +340,11 @@
             },
             "additionalProperties": false
         },
+        "locationSetCrossReference": {
+            "type": "string",
+            "pattern": "^\\{.+\\}$",
+            "description": "An string referencing another preset which has a locationSet"
+        },
         "urlFormat":  {
             "description": "Permalink URL for `identifier` fields. Must contain a {value} placeholder",
             "type": "string"

--- a/schemas/preset.json
+++ b/schemas/preset.json
@@ -135,6 +135,11 @@
             },
             "minProperties": 1,
             "additionalProperties": false
+        },
+        "locationSetCrossReference": {
+            "type": "string",
+            "pattern": "^\\{.+\\}$",
+            "description": "An string referencing another preset which has a locationSet"
         }
     },
     "additionalProperties": false,


### PR DESCRIPTION
Closes #151

dereferencing is done at compile-time, so this is not a breaking change. downstream consumers won't notice any difference.