### PR TITLE
store `terms` and `aliases` as an array in the translation files

### DIFF
--- a/lib/translations.js
+++ b/lib/translations.js
@@ -123,7 +123,7 @@ function fetchTranslations(options) {
                 let names = preset.name.split('\n').map(s => s.trim()).filter(Boolean);
                 preset.name = names[0];
                 if (names.length > 1) {
-                    preset.aliases = names.slice(1).join('\n');
+                    preset.aliases = names.slice(1);
                 }
             }
 
@@ -139,11 +139,9 @@ function fetchTranslations(options) {
                   .map(s => s.toLowerCase().trim())
                   // remove empty strings
                   .filter(Boolean)
-              ))
-              // convert back to a concatenated string
-              .join(',');
+              ));
 
-            if (!preset.terms) {
+            if (!preset.terms.length) {
               // no need to include empty terms
               delete preset.terms;
               if (!Object.keys(preset).length) {
@@ -167,11 +165,10 @@ function fetchTranslations(options) {
               .map(s => s.toLowerCase().trim())
               // remove empty strings
               .filter(Boolean)
-            ))
-            // convert back to a concatenated string
-            .join(',');
+            ));
 
-            if (!field.terms) {
+            if (!field.terms.length) {
+              // no need to include empty terms
               delete field.terms;
               if (!Object.keys(field).length) {
                 delete fields[key];


### PR DESCRIPTION
Closes #84 

Independant of #228 