### PR TITLE
consider other unicode commas when splitting translated `terms`

### DIFF
--- a/lib/translations.js
+++ b/lib/translations.js
@@ -162,7 +162,7 @@ function fetchTranslations(options) {
               // remove translation message if it was included somehow
               field.terms.replace(/\[.*\]/, '')
               // convert to an array
-              .split(',')
+              .split(/[,،、]/)
               // make everything lowercase and remove whitespace
               .map(s => s.toLowerCase().trim())
               // remove empty strings


### PR DESCRIPTION
Closes https://github.com/openstreetmap/id-tagging-schema/issues/472. Independent of #226

Translators with other keyboard layouts might use delimeters other than the [basic latin comma (`,`)](https://decodeunicode.org/U+002C).

For example the [arabic comma (`،`)](https://decodeunicode.org/U+060C), [CJK list comma (`、`)](https://decodeunicode.org/U+3001), and possibly [others](https://en.wikipedia.org/wiki/Enumeration_comma) that I'm not familiar with.

