### PR TITLE
add explicit schema for field.strings

### DIFF
--- a/schemas/field.json
+++ b/schemas/field.json
@@ -133,12 +133,30 @@
             "properties": {
                 "options": {
                     "description": "Translatable options (combo fields).",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": {
+                        "oneOf": [
+                            { "type": "string" },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "title": { "type": "string" },
+                                    "description": { "type": "string" }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "types": {
+                    "description": "Translatable types (directionalCombo and access only).",
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                },
+                "placeholders": {
+                    "description": "Translatable placeholders (address only).",
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
                 }
-            },
-            "additionalProperties": {
-                "description": "Specialized fields can request translation of arbitrary strings",
-                "type": "object"
             }
         },
         "stringsCrossReference": {


### PR DESCRIPTION
given the lack of documentation on this topic, we might as well use the schema to document what's allowed