### PR TITLE
allow individual field options to reference other translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,15 @@ to the different states of the checkbox input element, in the following order:
 _unchecked state_ ([example](https://github.com/openstreetmap/id-tagging-schema/blob/2375a6b/data/fields/parcel_pickup.json))
 2. fields of type `defaultCheck`: _unchecked state_ (must use the option `undefined`), _checked state_ ([example](https://github.com/openstreetmap/id-tagging-schema/blob/2375a6b/data/fields/crossing_raised.json))
 
+The value of each option can be a reference to another field or preset's name. For example:
+```json
+  "strings": {
+    "options": {
+      "portal_crane": "{presets/man_made/crane/portal_crane}",
+    }
+  }
+```
+
 ##### `stringsCrossReference`
 
 An optional property to reference to the strings of another field, indicated  by using that field's name contained in brackets, like `{field}`. This is for example useful when there are multiple variants of fields for the same tag, which should all use the same strings.

--- a/lib/build.js
+++ b/lib/build.js
@@ -415,6 +415,13 @@ function generateTranslations(fields, presets, tstrings, searchableFieldIDs) {
       yamlField['#label'] = `${field.key}=*`;
     }
     optkeys.forEach(k => {
+      if (typeof options[k] === 'string' && options[k].startsWith('{')) {
+        // skip, this references another field or preset, so we don't want
+        // translators to translate it.
+        delete options[k];
+        return;
+      }
+
       if (typeof options[k] === 'string'){
         options['#' + k] = field.key ? `${field.key}=${k}` : `field "${fieldId}" with value "${k}"`;
       } else {
@@ -584,6 +591,14 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
             valueLabel = tstrings.fields[field.stringsCrossReference.slice(1, -1)].options?.[value];
           }
           if (valueLabel && typeof valueLabel === 'string') {
+            const match = valueLabel.match(/^\{(.*)\}$/)?.[1];
+            if (match) {
+              const [group, ...remainder] = match.split('/');
+              const reference = tstrings[group][remainder.join('/')];
+              if (!reference) throw new Error(`${valueLabel} is not a valid reference`);
+
+              valueLabel = reference.name || reference.label;
+            }
             tag.description = [ `🄵🅅 ${label}: ${valueLabel}` ];
           } else {
             tag.description = [ `🄵🅅 ${label}: \`${value}\`` ];


### PR DESCRIPTION
Closes #162

for this PR, most of the logic will be in iD.

`fields.strings.options` be reference both presets _and_ fields, using the same syntax as #226 (`{presets/...}` or `{fields/...}`).

The target use case is for [fields like `fields/service.json`](https://github.com/openstreetmap/id-tagging-schema/blob/2d53ca9b6935227d2b52a1e52c9c2375e15dc5c8/data/fields/service.json#L5-L13), so that translations like `Driveway` and `Parking Aisle` can be referenced from the presets, instead of being re-defined in [`fields/service.json`](https://github.com/openstreetmap/id-tagging-schema/blob/2d53ca9b6935227d2b52a1e52c9c2375e15dc5c8/data/fields/service.json#L5-L13).
