### PR TITLE
support discarding tags, not just keys

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -668,15 +668,20 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
   });
 
   if (!discarded) discarded = {};
-  Object.keys(discarded).forEach(key => {
+  for (const key in discarded) {
     let description = '🄳🄳 (discarded tag)';
-    /** @type {TaginfoTag} */
-    let tag = {
-      key,
-      description: [description]
-    };
-    coalesceTags(taginfo, tag);
-  });
+    if (discarded[key] === true) {
+      // key=*
+      let tag = { key, description: [description] };
+      coalesceTags(taginfo, tag);
+    } else {
+      // key=value
+      for (const value in discarded[key]) {
+        const tag = { key, value, description: [description] };
+        coalesceTags(taginfo, tag);
+      }
+    }
+  }
 
   taginfo.tags.forEach(elem => {
     if (elem.description) {

--- a/schemas/discarded.json
+++ b/schemas/discarded.json
@@ -2,9 +2,16 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://github.com/ideditor/schema-builder/raw/main/schemas/discarded.json",
     "title": "Discarded tags",
-    "description": "Keys of tags to be deleted when editing features.",
+    "description": "Keys or tags to be deleted when editing features.",
     "type": "object",
     "additionalProperties": {
-        "type": "boolean"
+      "anyOf": [
+        { "type": "boolean", "enum": [true] },
+        {
+          "type": "object",
+          "additionalProperties": { "type": "boolean", "enum": [true] },
+          "minProperties": 1
+        }
+      ]
     }
 }


### PR DESCRIPTION
Currently, `discarded.json` only allows keys to be defined. This PR allows tags to be defined too.

For example, some values of `attribution=*` could be discardable, but not others.
```json
{
  "created_by": true,
  "attribution": {
    "https://......import garbage.......": true
  }
}
```

it's a https://github.com/ideditor/schema-builder/labels/breaking change for any apps who use `discarded.json`.

---

this is required because https://github.com/openstreetmap/id-tagging-schema/commit/a11968d8b6f73b18820e978e848fddeb0a755b3d is causing a weird inconsistency where iD is deleting some tags but not others (see [this way's history](https://osm.org/way/306448787/history))