### PR TITLE
Enhance 'reference' section with usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,13 +376,20 @@ When possible, use [`deprecated.json`](#deprecations) instead to specify upgrade
 
 ##### `reference`
 
-A key and optionally a value to link to the wiki documentation for this preset. Only necessary if the preset consists of several tags.
+A key and optionally a value to link to the wiki documentation for this preset. Only necessary if the preset consists of several tags or pages like [`Key:payment:*`](https://wiki.openstreetmap.org/wiki/Key:payment:*) should be referenced ([Example](https://github.com/openstreetmap/id-tagging-schema/blob/main/data/fields/payment_multi.json#L5-L7)).
 
-For example,
+Examples: 
+
 ```javascript
 "reference": {
     "key": "tower:type",
     "value": "communication"
+}
+```
+
+```javascript
+"reference": {
+    "key": "payment:*"
 }
 ```
 


### PR DESCRIPTION
There is a different use case for reference that we applied in https://github.com/openstreetmap/id-tagging-schema/pull/1701 to fix references for `payment:*` following @k-yle's suggestion from https://github.com/openstreetmap/iD/pull/11385#discussion_r2321432151

I think this is a different enough use case to give it some visibility in the docs.