### PR TITLE
fix bug where terms/aliases are not expanded for `en.json`

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -9,7 +9,7 @@ import marky from 'marky';
 import { createRequire } from 'module';
 import { compile, toSafeIdentifier } from 'json-schema-to-typescript-lite';
 
-import fetchTranslations from './translations.js';
+import fetchTranslations, { expandTStrings } from './translations.js';
 
 const require = createRequire(import.meta.url);
 
@@ -173,6 +173,7 @@ function processData(options, type) {
   if (deprecated) fs.writeFileSync(distDir + '/deprecated.json', JSON.stringify(deprecated, null, 4));
   if (discarded) fs.writeFileSync(distDir + '/discarded.json', JSON.stringify(discarded, null, 4));
 
+  expandTStrings(tstrings);
   let translationsForJson = {};
   translationsForJson[sourceLocale] = { presets: tstrings };
 

--- a/lib/translations.js
+++ b/lib/translations.js
@@ -4,6 +4,71 @@ import fetch from 'node-fetch';
 import YAML from 'js-yaml';
 import { transifexApi } from '@transifex/api';
 
+export function expandTStrings(tstrings) {
+  const presets = tstrings.presets || {};
+  for (const key of Object.keys(presets)) {
+    let preset = presets[key];
+
+    if (preset.name) {
+        let names = preset.name.split('\n').map(s => s.trim()).filter(Boolean);
+        preset.name = names[0];
+        if (names.length > 1) {
+            preset.aliases = names.slice(1);
+        }
+    }
+    if (typeof preset.aliases === 'string') {
+      preset.aliases = preset.aliases.split('\n');
+    }
+
+    if (!preset.terms) continue;
+
+    // remove duplicates
+    preset.terms = Array.from(new Set(
+        // remove translation message if it was included somehow
+        preset.terms.replace(/<.*>/, '')
+          // convert to an array
+          .split(',')
+          // make everything lowercase and remove whitespace
+          .map(s => s.toLowerCase().trim())
+          // remove empty strings
+          .filter(Boolean)
+      ));
+
+    if (!preset.terms.length) {
+      // no need to include empty terms
+      delete preset.terms;
+      if (!Object.keys(preset).length) {
+        delete presets[key];
+      }
+    }
+  }
+
+  const fields = tstrings.fields || {};
+  for (const key of Object.keys(fields)) {
+    let field = fields[key];
+    if (!field.terms) continue;
+
+    // remove duplicates
+    field.terms = Array.from(new Set(
+      // remove translation message if it was included somehow
+      field.terms.replace(/\[.*\]/, '')
+      // convert to an array
+      .split(/[,،]/)
+      // make everything lowercase and remove whitespace
+      .map(s => s.toLowerCase().trim())
+      // remove empty strings
+      .filter(Boolean)
+    ));
+
+    if (!field.terms.length) {
+      // no need to include empty terms
+      delete field.terms;
+      if (!Object.keys(field).length) {
+        delete fields[key];
+      }
+    }
+  }
+}
 
 function fetchTranslations(options) {
 
@@ -115,67 +180,7 @@ function fetchTranslations(options) {
 
         let locale = {};
         results.forEach((result, i) => {
-          let presets = (result.presets && result.presets.presets) || {};
-          for (const key of Object.keys(presets)) {
-            let preset = presets[key];
-
-            if (preset.name) {
-                let names = preset.name.split('\n').map(s => s.trim()).filter(Boolean);
-                preset.name = names[0];
-                if (names.length > 1) {
-                    preset.aliases = names.slice(1);
-                }
-            }
-
-            if (!preset.terms) continue;
-
-            // remove duplicates
-            preset.terms = Array.from(new Set(
-                // remove translation message if it was included somehow
-                preset.terms.replace(/<.*>/, '')
-                  // convert to an array
-                  .split(',')
-                  // make everything lowercase and remove whitespace
-                  .map(s => s.toLowerCase().trim())
-                  // remove empty strings
-                  .filter(Boolean)
-              ));
-
-            if (!preset.terms.length) {
-              // no need to include empty terms
-              delete preset.terms;
-              if (!Object.keys(preset).length) {
-                delete presets[key];
-              }
-            }
-          }
-
-          let fields = (result.presets && result.presets.fields) || {};
-          for (const key of Object.keys(fields)) {
-            let field = fields[key];
-            if (!field.terms) continue;
-
-            // remove duplicates
-            field.terms = Array.from(new Set(
-              // remove translation message if it was included somehow
-              field.terms.replace(/\[.*\]/, '')
-              // convert to an array
-              .split(/[,،]/)
-              // make everything lowercase and remove whitespace
-              .map(s => s.toLowerCase().trim())
-              // remove empty strings
-              .filter(Boolean)
-            ));
-
-            if (!field.terms.length) {
-              // no need to include empty terms
-              delete field.terms;
-              if (!Object.keys(field).length) {
-                delete fields[key];
-              }
-            }
-          }
-
+          expandTStrings(result.presets || {});
           locale[codes[i]] = result;
         });
 


### PR DESCRIPTION
Fixes a bug caused by #227 (which hasn't been released yet).

[en.json](https://github.com/openstreetmap/id-tagging-schema/blob/main/dist/translations/en.json) is special, it uses different code compared to all the translation files. The logic in #227 didn't affect `en.json`, which is a bug.


The git diff looks big, but the changes in this PR are actually quite small: 60 lines were just copied into a helper function, so that it can be re-used in a different place. 

---

<details>
<summary>testing log</summary>


Testing anything in this repo is a real pain. In iD tagging schema, I ran:
```sh
# first commit the changes from schema builder v7: 
npm i @ideditor/schema-builder@github:ideditor/schema-builder#main
npm i 
npm run build # manually fixed various errors during this step
npm run dist
npm run translations

git add .
git commit -m "commiting the baseline"


# now commit the changes from this PR:
npm i @ideditor/schema-builder@github:ideditor/schema-builder#kh/sort-obj
npm i 
npm run build
npm run dist
npm run translations

git add .
git commit -m "commiting the changes from this PR"

```
and then check the diff between the two commits. [f2b680](https://github.com/k-yle/id-tagging-schema/commit/f2b680c5608efb5d2887f996cc99a22cd0db28dc) is the result when i ran these steps. The only affected files are `en.json` and `en.min.json`


</details>
