### PR TITLE
dereference at build-time

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -8,7 +8,7 @@ import YAML from 'js-yaml';
 import marky from 'marky';
 import { createRequire } from 'module';
 import { compile, toSafeIdentifier } from 'json-schema-to-typescript-lite';
-
+import { isReference, dereferencedTranslatableContent, dereferenceUntranslatedContent } from './references.js';
 import fetchTranslations, { expandTStrings, sortObject } from './translations.js';
 
 const require = createRequire(import.meta.url);
@@ -117,15 +117,19 @@ function processData(options, type) {
   let categories = generateCategories(dataDir, tstrings);
   if (options.processCategories) options.processCategories(categories);
 
-  let fields = generateFields(dataDir, tstrings, searchableFieldIDs);
+  /** @type {References} */
+  const references = { fields: {}, presets: {} };
+  let fields = generateFields(dataDir, tstrings, searchableFieldIDs, references);
   if (options.processFields) options.processFields(fields);
 
-  let presets = generatePresets(dataDir, tstrings, searchableFieldIDs, options.listReusedIcons);
+  let presets = generatePresets(dataDir, tstrings, searchableFieldIDs, options.listReusedIcons, references);
   if (options.processPresets) options.processPresets(presets);
 
   // Additional consistency checks
   validateCategoryPresets(categories, presets);
   validatePresetFields(presets, fields);
+
+  dereferenceUntranslatedContent(presets, fields);
 
   const defaults = read(dataDir + '/preset_defaults.json');
   if (defaults) {
@@ -149,6 +153,8 @@ function processData(options, type) {
 
   let icons = generateIconsList(presets, fields, categories);
   fs.writeFileSync(interimDir + '/icons.json', JSON.stringify(icons, null, 4));
+
+  dereferencedTranslatableContent(tstrings, references, true);
 
   if (type !== 'build-dist') return;
 
@@ -198,7 +204,7 @@ function processData(options, type) {
   ];
 
   if (doFetchTranslations) {
-    tasks.push(fetchTranslations(options));
+    tasks.push(fetchTranslations(options, references));
   }
   return Promise.all(tasks);
 }
@@ -247,7 +253,7 @@ function generateCategories(dataDir, tstrings) {
 }
 
 
-function generateFields(dataDir, tstrings, searchableFieldIDs) {
+function generateFields(dataDir, tstrings, searchableFieldIDs, references) {
   let fields = {};
 
   fs.globSync(dataDir + '/fields/**/*.json', {
@@ -262,10 +268,13 @@ function generateFields(dataDir, tstrings, searchableFieldIDs) {
 
     const label = field.label;
 
-    if (!label.startsWith('{')) {
+    if (isReference(label)) {
+      references.fields[id] ||= {};
+      references.fields[id].labelAndTerms = label;
+    } else {
       t.label = label;
-      delete field.label;
     }
+    delete field.label;
 
     validateTerms(field.terms, `field "${id}"`);
     tstrings.fields[id].terms = Array.from(new Set(
@@ -279,19 +288,40 @@ function generateFields(dataDir, tstrings, searchableFieldIDs) {
       searchableFieldIDs[id] = true;
     }
 
-    if (field.placeholder && !field.placeholder.startsWith('{')) {
-      t.placeholder = field.placeholder;
+    if (field.placeholder) {
+      if (isReference(field.placeholder)) {
+        references.fields[id] ||= {};
+        references.fields[id].placeholder = field.placeholder;
+      } else {
+        t.placeholder = field.placeholder;
+      }
       delete field.placeholder;
     }
 
     if (field.strings) {
-      for (let key in field.strings) {
-        t[key] = field.strings[key];
+      for (let prop in field.strings) {
+        t[prop] = {};
+        for (const [key, value] of Object.entries(field.strings[prop])) {
+          if (typeof value === 'string' && isReference(value)) {
+            references.fields[id] ||= {};
+            references.fields[id].options ||= {};
+            references.fields[id].options[prop] ||= {};
+            references.fields[id].options[prop][key] = value;
+          } else {
+            t[prop][key] = value;
+          }
+        }
       }
       if (!field.options && field.strings.options) {
         field.options = Object.keys(field.strings.options);
       }
       delete field.strings;
+    }
+
+    if (field.stringsCrossReference) {
+      references.fields[id] ||= {};
+      references.fields[id].stringsCrossReference = field.stringsCrossReference;
+      delete field.stringsCrossReference;
     }
 
     fields[id] = field;
@@ -308,7 +338,7 @@ function stripLeadingUnderscores(str) {
 }
 
 
-function generatePresets(dataDir, tstrings, searchableFieldIDs, listReusedIcons) {
+function generatePresets(dataDir, tstrings, searchableFieldIDs, listReusedIcons, references) {
   let presets = {};
 
   let icons = {};
@@ -330,11 +360,12 @@ function generatePresets(dataDir, tstrings, searchableFieldIDs, listReusedIcons)
     let names = new Set([]);
     tstrings.presets[id] = {};
 
-    if (!preset.name.startsWith('{')) {
+    if (isReference(preset.name)) {
+      references.presets[id] ||= {};
+      references.presets[id].nameTermsAliases = preset.name;
+    } else {
       tstrings.presets[id].name = preset.name;
       names.add(preset.name.toLowerCase());
-      // don't include localized strings in the presets dist file since they're already in the locale file
-      delete preset.name;
     }
 
     preset.aliases = Array.from(new Set(
@@ -359,6 +390,8 @@ function generatePresets(dataDir, tstrings, searchableFieldIDs, listReusedIcons)
     // don't include localized strings in the presets dist file since they're already in the locale file
     delete preset.aliases;
     delete preset.terms;
+    delete preset.name;
+
 
     if (preset.moreFields) {
       preset.moreFields.forEach(fieldID => { searchableFieldIDs[fieldID] = true; });
@@ -424,13 +457,6 @@ function generateTranslations(fields, presets, tstrings, searchableFieldIDs) {
       yamlField['#label'] = `${field.key}=*`;
     }
     optkeys.forEach(k => {
-      if (typeof options[k] === 'string' && options[k].startsWith('{')) {
-        // skip, this references another field or preset, so we don't want
-        // translators to translate it.
-        delete options[k];
-        return;
-      }
-
       if (typeof options[k] === 'string'){
         options['#' + k] = field.key ? `${field.key}=${k}` : `field "${fieldId}" with value "${k}"`;
       } else {
@@ -562,7 +588,7 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
 
 
         let name = tstrings.presets[id].name;
-        if (!name && preset.name.startsWith('{')) {
+        if (!name && isReference(preset.name)) {
           name = tstrings.presets[preset.name.slice(1, -1)].name;
         }
         let legacy = (preset.searchable === false) ? ' (unsearchable)' : '';
@@ -609,7 +635,7 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
       let tag = { key: key };
 
       let label = tstrings.fields[id].label;
-      if (!label && field.label.startsWith('{')) {
+      if (!label && field.label && isReference(field.label)) {
         label = tstrings.fields[field.label.slice(1, -1)].label;
       }
       tag.description = [ `🄵 ${label}` ];
@@ -627,18 +653,8 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
             tag = { key: key, value: value };
           }
           let valueLabel = tstrings.fields[id].options?.[value];
-          if (!valueLabel && field.stringsCrossReference) {
-            valueLabel = tstrings.fields[field.stringsCrossReference.slice(1, -1)].options?.[value];
-          }
-          if (valueLabel && typeof valueLabel === 'string') {
-            const match = valueLabel.match(/^\{(.*)\}$/)?.[1];
-            if (match) {
-              const [group, ...remainder] = match.split('/');
-              const reference = tstrings[group][remainder.join('/')];
-              if (!reference) throw new Error(`${valueLabel} is not a valid reference`);
 
-              valueLabel = reference.name || reference.label;
-            }
+          if (valueLabel && typeof valueLabel === 'string') {
             tag.description = [ `🄵🅅 ${label}: ${valueLabel}` ];
           } else {
             tag.description = [ `🄵🅅 ${label}: \`${value}\`` ];

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,5 @@
 import { buildDev, buildDist, validate } from './build.js';
-import fetchTranslations from './translations.js';
 
 export default {
     buildDev, buildDist, validate,
-    fetchTranslations
 };

--- a/lib/references.js
+++ b/lib/references.js
@@ -1,0 +1,165 @@
+/** @param {string} string */
+export function isReference(string) {
+  return string.startsWith('{') && string.endsWith('}');
+}
+
+/**
+ * This is only used to expand references to _untranslated content_.
+ * For example, `fields` can reference the list of field IDs from another
+ * preset.
+ */
+export function dereferenceUntranslatedContent(presets, fields) {
+  for (const presetID in presets) {
+    const preset = presets[presetID];
+
+    // 1. fields and moreFields can reference other presets
+    for (const prop of ['fields', 'moreFields']) {
+      if (!preset[prop]) continue;
+      for (let i = 0; i < preset[prop].length || 0; i++) {
+        const otherPresetID = preset[prop][i];
+        if (isReference(otherPresetID)) {
+          const referencedPreset = presets[otherPresetID.slice(1, -1)];
+
+          if (!referencedPreset) {
+            throw new Error(
+              `Preset “${presetID}” references “${otherPresetID}” in ${prop}.${i}, but there is no such preset.`,
+            );
+          }
+
+          // preset (A) references the fields of preset (B), but (B) has no
+          // fields. For now, we silently skip this to match the existing logic,
+          // but in the future we could emit an error here. (TODO:)
+          if (!referencedPreset[prop]) {
+            preset[prop].splice(i--, 1);
+            continue;
+          }
+
+          // replace the reference with every field. decrement i to reprocess this array index.
+          preset[prop].splice(i--, 1, ...referencedPreset[prop]);
+        }
+      }
+    }
+  }
+
+  for (const fieldID in fields) {
+    const field = fields[fieldID];
+
+    // 2. fields can reference icons from other presets
+    if (field.iconsCrossReference) {
+      const referencedField = fields[field.iconsCrossReference.slice(1, -1)];
+
+      if (!referencedField) {
+        throw new Error(
+          `Field “${fieldID}” references “${field.iconsCrossReference}” in iconsCrossReference, but there is no such field.`,
+        );
+      }
+
+      field.icons = referencedField.icons;
+      delete field.iconsCrossReference;
+    }
+  }
+}
+
+/**
+ * Copies translated strings to the presets that reference these strings.
+ */
+export function dereferencedTranslatableContent(tstrings, references, strict) {
+  for (const presetID in references.presets) {
+    // skip missing field, this language must have incomplete translations
+    if (!tstrings.presets?.[presetID]) continue;
+
+    const p = references.presets[presetID];
+    // 4. presets can reference the name + terms + aliases from other presets
+    if (p.nameTermsAliases) {
+      const referencedPreset =
+        tstrings.presets[p.nameTermsAliases.slice(1, -1)];
+
+      if (referencedPreset) {
+        tstrings.presets[presetID].name = referencedPreset.name;
+        tstrings.presets[presetID].aliases = referencedPreset.aliases;
+        tstrings.presets[presetID].terms = referencedPreset.terms;
+      } else if (strict) {
+        throw new Error(
+          `Preset “${presetID}” references “${p.nameTermsAliases}” in the name, but there is no such preset.`,
+        );
+      }
+    }
+  }
+
+  for (const fieldID in references.fields) {
+    // skip missing field, this language must have incomplete translations
+    if (!tstrings.fields?.[fieldID]) continue;
+
+    const f = references.fields[fieldID];
+    // 5. fields can reference the label + terms from other fields
+    if (f.labelAndTerms) {
+      const referencedField = tstrings.fields[f.labelAndTerms.slice(1, -1)];
+
+      if (referencedField) {
+        tstrings.fields[fieldID].label = referencedField.label;
+        tstrings.fields[fieldID].terms = referencedField.terms;
+      } else if (strict) {
+        throw new Error(
+          `Field “${fieldID}” references “${f.labelAndTerms}” in the label, but there is no such field.`,
+        );
+      }
+    }
+
+    // 6. fields can reference the placeholder from other fields
+    if (f.placeholder) {
+      const referencedField = tstrings.fields[f.placeholder.slice(1, -1)];
+
+      if (referencedField) {
+        tstrings.fields[fieldID].placeholder = referencedField.placeholder;
+      } else if (strict) {
+        throw new Error(
+          `Field “${fieldID}” references “${f.placeholder}” in the placeholder, but there is no such field.`,
+        );
+      }
+    }
+
+    // 7. fields can reference the entire strings.options object from other fields
+    if (f.stringsCrossReference) {
+      const referencedField =
+        tstrings.fields[f.stringsCrossReference.slice(1, -1)];
+
+      if (referencedField) {
+        for (const prop in referencedField) {
+          if (typeof referencedField[prop] === 'object') {
+            tstrings.fields[fieldID][prop] = referencedField[prop];
+          }
+        }
+      } else if (strict) {
+        throw new Error(
+          `Field “${fieldID}” references “${f.stringsCrossReference}” in stringsCrossReference, but there is no such field.`,
+        );
+      }
+    }
+
+    // 8. specific field options can reference the label from other fields *and from other presets*
+    if (f.options) {
+      for (const prop in f.options) {
+        for (const key in f.options[prop]) {
+          const [type, ...foreignId] = f.options[prop][key]
+            .slice(1, -1)
+            .split('/');
+          const referenced =
+            type === 'presets'
+              ? tstrings.presets[foreignId.join('/')].name
+              : type === 'fields'
+                ? tstrings.fields[foreignId.join('/')].label
+                : undefined;
+
+          if (referenced) {
+            tstrings.fields[fieldID][prop] ||= {};
+            tstrings.fields[fieldID][prop][key] = referenced;
+          } else if (strict) {
+            throw new Error(
+              `Field “${fieldID}” references “${foreignId}” in options.${prop}.${key}, but there is no such ${type}.`,
+            );
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/translations.js
+++ b/lib/translations.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import fetch from 'node-fetch';
 import YAML from 'js-yaml';
 import { transifexApi } from '@transifex/api';
+import { dereferencedTranslatableContent } from './references.js';
 
 export function expandTStrings(tstrings) {
   const presets = tstrings.presets || {};
@@ -82,7 +83,7 @@ export function sortObject(original) {
   return sorted;
 }
 
-function fetchTranslations(options) {
+function fetchTranslations(options, references) {
 
   // Transifex doesn't allow anonymous downloading
   /* eslint-disable no-process-env */
@@ -215,6 +216,9 @@ function fetchTranslations(options) {
     });
 
     for (let code in allStrings) {
+      if (allStrings[code].presets) {
+        dereferencedTranslatableContent(allStrings[code].presets, references, false);
+      }
       let obj = {};
       obj[code] = allStrings[code] || {};
       fs.writeFileSync(`${outDir}/${code}.json`, JSON.stringify(obj, null, 4));

--- a/tests/schema-builder.test.js
+++ b/tests/schema-builder.test.js
@@ -44,7 +44,6 @@ describe('schema-builder', () => {
     expect(schemaBuilder && schemaBuilder.buildDist).not.toBeUndefined();
     expect(schemaBuilder && schemaBuilder.buildDev).not.toBeUndefined();
     expect(schemaBuilder && schemaBuilder.validate).not.toBeUndefined();
-    expect(schemaBuilder && schemaBuilder.fetchTranslations).not.toBeUndefined();
   });
 
   it('runs validate', () => {


### PR DESCRIPTION
Closes #266

There are two types of references: 
1. references to translatable content, like `label`, `terms`, `stringsCrossReference`, etc.
2. references to non-translatable content, like `iconsCrossReference`, or `"{@templates/contact}"` in `fields`.

They are handled differently because of how this repo is structured. crude flowchart to explain:

```mermaid
flowchart LR
    classDef new fill:#013220
    
    A("/presets/**/*.json\n/fields/**/*.json") --> B
    B("Merge all files") --> C
    C("Split translatable content") --> D
    C --> K

    D("Translatable content") -->|Upload source_strings.yaml| E
    E("Transifex") -->|Download *.json| F
    F("🆕Dereference translatable content🆕"):::new --> G
    G("/dist/translations/*.json")

    K("non-translatable content") --> L
    L("🆕Dereference non-translatable content🆕"):::new --> M
    M("/dist/presets.json\n/dist/fields.json")
```
Only the $`{\color{#013220} \blacksquare}`$ green boxes are added, nothing else is changed.

---

#### impact on the `/dist` files
- `/dist/translations/*.json`
  - every field and preset will contain translations, so the uncompressed file size will increase slightly.
- `/dist/fields.json`:
  - will never include `stringsCrossReference` and `iconsCrossReference`
  - will never include `label` or `placeholder`, currently these fields only exists if the value is a reference like `"{natural/wood}"`
- `/dist/presets.json`
  - will never include fields like `name`, currently these fields only exists if the value is a reference like `"{natural/wood}"`
  - `fields` and `moreFields` will never contain references like `"{@templates/contact}"`, they are already expanded.
- all other files: no change.

#### impact for data consumers
- `stringsCrossReference` and `iconsCrossReference` are never exposed to downstream apps, consumers don't need to handle this anymore. 
- references like `{...}` are never exposed to downstream apps, consumers don't need to handle this anymore. 

#### impact for id-tagging-schema
- currently there are two ways to trigger `fetchTranslations`: using `node scripts/translations.js` or `npm run dist translations`. The former has been removed, since it adds complexity to maintain 2 different ways of doing the same thing. minor change required in the id-tagging-schema repo when schema-builder v7 is released.

#### impact on file size
gzipped sizes:
* `/dist/translations/en.min.json`: 291kB -> 293kB &nbsp; &nbsp; +0.69%
* `/dist/presets.min.json`: 48kB -> 51kB &nbsp; &nbsp; +6%
* `/dist/fields.min.json`: 23kB -> 23kB &nbsp; &nbsp; -0%

#### test plan

to see the impact on `/dist/*`, see commit [2f9d3918](http://github.com/openstreetmap/id-tagging-schema/commit/2f9d3918011d68122e852728fdbcb843f18851b4) where I've commited the diff
