### PR TITLE
Add segregated combo field and fallback field key

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -946,6 +946,30 @@ function validatePresetFields(presets, fields) {
       }
     }
 
+    // Check that no field with a fallbackKey has its fallback field also explicitly listed,
+    // and that fallbackKey references are valid fields
+    let allPresetFieldIDs = new Set([
+      ...(preset.fields || []),
+      ...(preset.moreFields || [])
+    ]);
+    for (let fieldID of allPresetFieldIDs) {
+      let field = fields[fieldID];
+      if (!field?.fallbackKey) continue;
+
+      let fallbackField = fields[field.fallbackKey];
+      if (!fallbackField) {
+        process.stderr.write('Unknown fallback field "' + field.fallbackKey + '" referenced by field "' + fieldID + '" in preset "' + presetID + '" (' + preset.name + ')\n');
+        process.stdout.write('\n');
+        process.exit(1);
+      }
+
+      if (allPresetFieldIDs.has(field.fallbackKey)) {
+        process.stderr.write('The preset "' + presetID + '" includes repeated field "' + field.fallbackKey + '" already implicitly included by field "' + fieldID + '" as a fallback field\n');
+        process.stdout.write('\n');
+        process.exit(1);
+      }
+    }
+
     if (preset.fields) {
       // since `moreFields` is available, check that `fields` doesn't get too cluttered
       let fieldCount = preset.fields.length;

--- a/lib/build.js
+++ b/lib/build.js
@@ -990,12 +990,23 @@ function validatePresetFields(presets, fields) {
       }
     }
   }
-
+  
   for (let fieldID in fields) {
+    let field = fields[fieldID];
+
     if (!usedFieldIDs.has(fieldID) &&
-        fields[fieldID].universal !== true &&
-        (fields[fieldID].usage || 'preset') === 'preset') {
-      process.stdout.write('Field "' + fields[fieldID].label + '" (' + fieldID + ') isn\'t used by any presets.\n');
+        field.universal !== true &&
+        (field.usage || 'preset') === 'preset') {
+      process.stdout.write('Field "' + field.label + '" (' + fieldID + ') isn\'t used by any presets.\n');
+    }
+
+    if (field.fallbackKey) {
+      let fallbackField = fields[field.fallbackKey];
+      if (fallbackField?.fallbackKey) {
+        process.stderr.write('Field "' + field.fallbackKey + '" is used as a fallback by field "' + fieldID + '" but itself has a fallbackKey "' + fallbackField.fallbackKey + '". Recursive fallback fields are not allowed.\n');
+        process.stdout.write('\n');
+        process.exit(1);
+      }
     }
   }
 }

--- a/schemas/field.json
+++ b/schemas/field.json
@@ -76,6 +76,7 @@
                 "roadheight",
                 "roadspeed",
                 "schedule",
+                "segregatedCombo",
                 "semiCombo",
                 "structureRadio",
                 "tel",
@@ -209,6 +210,10 @@
             "description": "The amount the stepper control should add or subtract (number fields only)",
             "minimum": 1,
             "type": "integer"
+        },
+        "fallbackKey": {
+            "description": "The field that is shown instead when this field's visibility requirements are not met",
+            "type": "string"
         },
         "prerequisiteTag": {
             "description": "Tagging constraint for showing this field in the editor",
@@ -379,9 +384,9 @@
             { "not": { "required": ["keys"] }}
         ]},
         { "$id": "field-type-with-key-optional-keys", "properties": { "type": { "enum": ["email", "url", "tel", "text", "number"] } }, "required": ["key"] },
-        { "$id": "field-type-with-key-and-keys", "properties": { "type": { "enum": ["address", "wikipedia", "wikidata", "directionalCombo"] } }, "required": ["key", "keys"] },
+        { "$id": "field-type-with-key-and-keys", "properties": { "type": { "enum": ["address", "wikipedia", "wikidata", "directionalCombo", "segregatedCombo"] } }, "required": ["key", "keys"] },
         { "$id": "field-type-with-key-or-keys", "allOf": [
-            { "not": { "properties": { "type": { "enum": ["restriction", "email", "url", "tel", "text", "number", "address", "wikipedia", "wikidata", "directionalCombo"] } } } },
+            { "not": { "properties": { "type": { "enum": ["restriction", "email", "url", "tel", "text", "number", "address", "wikipedia", "wikidata", "directionalCombo", "segregatedCombo"] } } } },
             { "oneOf": [
                 { "required": ["key"] },
                 { "required": ["keys"] }


### PR DESCRIPTION
This is a prerequisite for https://github.com/openstreetmap/iD/pull/12332 to add a new segregated combo box field for (surface) sub-keys.

It adds `segregatedCombo` as a new field type and `fallbackKey` as a new field key.

I also sanity checked a couple assumption about the new key during the validation steps.