### PR TITLE
taginfo manifest - more accurate listing of supported keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,9 +520,9 @@ A string specifying the UI and behavior of the field. Must be one of the followi
 * `combo` - Dropdown field for picking one option out of many (e.g. `surface=*`)
 * `typeCombo` - Dropdown field picking a specific type from a generic category key<br/>
 (e.g. `waterway=*`.  If unset, tag will be `waterway=yes`, but dropdown contains options like `stream`, `ditch`, `river`)
-* `multiCombo` - Dropdown field for adding `yes` values to multiple keys with the same prefix (a common multikey)<br/>
-(e.g. `recycling:*` -> `recycling:glass=yes`, `recycling:paper=yes`, etc.)
-* `manyCombo` - Dropdown field for adding `yes` values to many different keys<br/>
+* `multiCombo` - Dropdown field for adding `yes` value to multiple keys with the same prefix (a common multikey) and suffixes selected among specified options<br/>
+(e.g. `recycling:*` as prefix and `glass`, `paper` as suffixes  -> `recycling:glass=yes`, `recycling:paper=yes`)
+* `manyCombo` - Dropdown field for adding `yes` values to many different keys from a specified list<br/>
 (e.g. `bus`, `tram`, `train` -> `bus=yes`, `tram=yes`, etc.)
 * `networkCombo` - Dropdown field that helps users pick a route `network` tag (localized for editing location)
 * `semiCombo` - Dropdown field for adding multiple values to a semicolon-delimited list<br/>

--- a/lib/build.js
+++ b/lib/build.js
@@ -673,7 +673,9 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
       }
       tag.description = [ `🄵 ${label}` ];
 
-      coalesceTags(taginfo, tag);
+      if (areAnyFreeFormTagsAcceptedInField(field)) {
+        coalesceTags(taginfo, tag);
+      }
 
       if (field.options && !isRadio && field.type !== 'manyCombo') {
         field.options.forEach(value => {
@@ -746,6 +748,15 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
     }
   });
 
+  function areAnyFreeFormTagsAcceptedInField(field) {
+    if (['multiCombo', 'manyCombo', 'check', 'defaultCheck', 'onewayCheck'].includes(field.type)) {
+      return false;
+    }
+    if (field.autoSuggestion === false && field.customValues === false) {
+      return false;
+    }
+    return true;
+  }
 
   /**
    * @param {TaginfoSchema} taginfo

--- a/lib/build.js
+++ b/lib/build.js
@@ -676,6 +676,15 @@ function generateTaginfo(presets, fields, deprecated, discarded, tstrings, proje
       if (areAnyFreeFormTagsAcceptedInField(field)) {
         coalesceTags(taginfo, tag);
       }
+      let yesTag = { ...tag, value: 'yes', description: [`🄵🅅 ${label}: yes`] };
+      let noTag  = { ...tag, value: 'no', description: [`🄵🅅 ${label}: no`] };
+      if (field.type === 'defaultCheck') {
+        coalesceTags(taginfo, yesTag);
+      }
+      if (field.type === 'check' || field.type === 'onewayCheck') {
+        coalesceTags(taginfo, yesTag);
+        coalesceTags(taginfo, noTag);
+      }
 
       if (field.options && !isRadio && field.type !== 'manyCombo') {
         field.options.forEach(value => {


### PR DESCRIPTION
specify in docs that multiCombo and manyCombo are not expected to support freeform values
do not claim that suffix from multiCombo is supported key 
do not claim that multiCombo, manyCombo, check, defaultCheck, onewayCheck are supporting freeform values
if field disabled autoSuggestion and customValues - do not list it as supporting freeform values
record also yes and no (where applicable) values of checboxes

fixes #273 but properly - require also customValues to be false 
fixes #286

changes can be seen at https://github.com/openstreetmap/id-tagging-schema/commit/0852f217

patchfile of output changes: https://github.com/openstreetmap/id-tagging-schema/commit/0852f217.patch