### PR TITLE
do not forbid matching to multiple presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ This property is required. There is no default.
 
 An object with the `"key": "value"` tags a feature must have to match this preset. A `"*"` wildcard value can be set to have this preset match any value for that key.
 
-A feature can only match one preset even if its tags and geometry could technically match more than one. iD will pick the best match based on `matchScore`, the number of tags, and the use of wildcard values.
+iD will pick the best match based on `matchScore`, the number of tags, and the use of wildcard values. A feature will be matched to one preset even if its tags and geometry fit more than one. 
 
 This property is required. There is no default.
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ This property is required. There is no default.
 
 An object with the `"key": "value"` tags a feature must have to match this preset. A `"*"` wildcard value can be set to have this preset match any value for that key.
 
-iD will pick the best match based on `matchScore`, the number of tags, and the use of wildcard values. A feature will be matched to one preset even if its tags and geometry fit more than one. 
+iD will pick the best match based on `matchScore`, the number of tags, and the use of wildcard values. A feature will be matched to one preset even if its tags and geometry fit more than one.
 
 This property is required. There is no default.
 


### PR DESCRIPTION
In principle nothing blocks editor using multiple presets at once in some way (see also https://github.com/openstreetmap/iD/issues/12123 )

iD is unlikely to do it any time soon, but I see no reason to ban doing this for other editors or software